### PR TITLE
Feat/broker code

### DIFF
--- a/contracts/referalRegistry.sol
+++ b/contracts/referalRegistry.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract ReferralRegistry {
+    struct Chain {
+        address[5] upline;
+        bool locked;
+    }
+
+    mapping(bytes32 => address) public codeOwner;     // broker code -> owner
+    mapping(address => Chain) public chainOf;         // trader -> upline snapshot
+
+    event CodeCreated(address indexed owner, bytes32 indexed codeHash, string code);
+    event ReferrerSet(
+        address indexed trader,
+        address indexed inviter,
+        bytes32 indexed codeHash,
+        address[5] upline
+    );
+
+    error CodeTaken();
+    error InvalidCode();
+    error AlreadyLocked();
+    error SelfReferral();
+
+    function createCode(string calldata code) external {
+        bytes32 h = keccak256(abi.encodePacked(code));
+        if (codeOwner[h] != address(0)) revert CodeTaken();
+        codeOwner[h] = msg.sender;
+        emit CodeCreated(msg.sender, h, code);
+    }
+
+    function setReferrerWithCode(bytes32 codeHash) external {
+        Chain storage c = chainOf[msg.sender];
+        if (c.locked) revert AlreadyLocked();
+
+        address inviter = codeOwner[codeHash];
+        if (inviter == address(0)) revert InvalidCode();
+        if (inviter == msg.sender) revert SelfReferral();
+
+        // Build upline snapshot from inviter
+        Chain storage pi = chainOf[inviter];
+        c.upline[0] = inviter;
+        for (uint i = 1; i < 5; i++) {
+            c.upline[i] = pi.upline[i-1];
+        }
+        c.locked = true;
+        emit ReferrerSet(msg.sender, inviter, codeHash, c.upline);
+    }
+
+    function getUpline(address trader) external view returns (address[5] memory) {
+        return chainOf[trader].upline;
+    }
+
+    function isLocked(address trader) external view returns (bool) {
+        return chainOf[trader].locked;
+    }
+}

--- a/contracts/rewardDistributor.sol
+++ b/contracts/rewardDistributor.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import './interfaces/IERC20.sol';
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+
+contract RewardsDistributor is ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    mapping(address => mapping(address => uint256)) public accrued; // token => user => amount
+    address public router;
+
+    event Accrued(address indexed token, address indexed recipient, uint256 amount, address indexed trader, uint8 level);
+    event Claimed(address indexed token, address indexed recipient, uint256 amount, address to);
+    event RouterSet(address router);
+
+    error NotRouter();
+
+    constructor(address _router) {
+        router = _router;
+        emit RouterSet(_router);
+    }
+
+    function setRouter(address _router) external {
+        // make ownable if needed; omitted here for brevity
+        router = _router;
+        emit RouterSet(_router);
+    }
+
+    function accrue(
+        address token,
+        address trader,
+        address[5] memory upline,
+        uint256 grossOut
+    ) external {
+        if (msg.sender != router) revert NotRouter();
+        // 10 bps per level present
+        for (uint8 i = 0; i < 5; i++) {
+            address r = upline[i];
+            if (r == address(0)) break;
+            uint256 cut = (grossOut * 10) / 10_000; // 0.1%
+            accrued[token][r] += cut;
+            emit Accrued(token, r, cut, trader, i + 1);
+        }
+    }
+
+    function claim(address token, address to) external nonReentrant {
+        uint256 amt = accrued[token][msg.sender];
+        if (amt == 0) return;
+        accrued[token][msg.sender] = 0;
+        IERC20(token).safeTransfer(to, amt);
+        emit Claimed(token, msg.sender, amt, to);
+    }
+}

--- a/contracts/rewardDistributor.sol
+++ b/contracts/rewardDistributor.sol
@@ -1,33 +1,49 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import './interfaces/IERC20.sol';
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
-contract RewardsDistributor is ReentrancyGuard {
+contract RewardsDistributor is ReentrancyGuard, Ownable {
     using SafeERC20 for IERC20;
 
-    mapping(address => mapping(address => uint256)) public accrued; // token => user => amount
+    // token => user => amount
+    mapping(address => mapping(address => uint256)) public accrued;
+
     address public router;
+    address public treasury;
 
     event Accrued(address indexed token, address indexed recipient, uint256 amount, address indexed trader, uint8 level);
     event Claimed(address indexed token, address indexed recipient, uint256 amount, address to);
     event RouterSet(address router);
+    event TreasurySet(address treasury);
 
     error NotRouter();
+    error ZeroAddress();
 
-    constructor(address _router) {
+    constructor(address _router, address _treasury) {
+        if (_router == address(0) || _treasury == address(0)) revert ZeroAddress();
+        router = _router;
+        treasury = _treasury;
+        emit RouterSet(_router);
+        emit TreasurySet(_treasury);
+    }
+
+    function setRouter(address _router) external onlyOwner {
+        if (_router == address(0)) revert ZeroAddress();
         router = _router;
         emit RouterSet(_router);
     }
 
-    function setRouter(address _router) external {
-        // make ownable if needed; omitted here for brevity
-        router = _router;
-        emit RouterSet(_router);
+    function setTreasury(address _treasury) external onlyOwner {
+        if (_treasury == address(0)) revert ZeroAddress();
+        treasury = _treasury;
+        emit TreasurySet(_treasury);
     }
 
+    /// @notice Allocate 5 × 0.1% = 0.5% total. Empty upline slots backfill to treasury.
     function accrue(
         address token,
         address trader,
@@ -35,13 +51,15 @@ contract RewardsDistributor is ReentrancyGuard {
         uint256 grossOut
     ) external {
         if (msg.sender != router) revert NotRouter();
-        // 10 bps per level present
+
+        // Per-slot cut: 0.1%
+        uint256 perSlot = (grossOut * 10) / 10_000; // 10 bps
+        // Credit 5 slots (levels 1..5). Empty slot -> treasury.
         for (uint8 i = 0; i < 5; i++) {
             address r = upline[i];
-            if (r == address(0)) break;
-            uint256 cut = (grossOut * 10) / 10_000; // 0.1%
-            accrued[token][r] += cut;
-            emit Accrued(token, r, cut, trader, i + 1);
+            if (r == address(0)) r = treasury;
+            accrued[token][r] += perSlot;
+            emit Accrued(token, r, perSlot, trader, i + 1);
         }
     }
 


### PR DESCRIPTION
TODO:  this should be added to core contracts or swaprouter
Hold immutable references to ReferralRegistry and RewardsDistributor.

When performing swaps, set the final pair’s to = address(this), then:

compute affiliate fee based on upline depth,

send fee to distributor (first transfer tokens to distributor, then call accrue),

forward net to the user.